### PR TITLE
Add bcrypt hash to the secret

### DIFF
--- a/htpasswd.tf
+++ b/htpasswd.tf
@@ -17,6 +17,7 @@ resource "aws_secretsmanager_secret_version" "pypiserver_secret" {
     {
       username : random_pet.username.id
       password : random_password.password.result
+      bcrypt_hash : random_password.password.bcrypt_hash
     }
   )
 }

--- a/main.tf
+++ b/main.tf
@@ -8,6 +8,7 @@ module "pypiserver" {
     aws     = aws
     aws.dns = aws.dns
   }
+  alb_healthcheck_path          = "/"
   asg_subnets                   = var.asg_subnets
   asg_min_size                  = 1
   asg_max_size                  = 1
@@ -40,7 +41,7 @@ module "pypiserver" {
       content = format(
         "%s:%s",
         jsondecode(aws_secretsmanager_secret_version.pypiserver_secret.secret_string)["username"],
-        bcrypt(jsondecode(aws_secretsmanager_secret_version.pypiserver_secret.secret_string)["password"])
+        jsondecode(aws_secretsmanager_secret_version.pypiserver_secret.secret_string)["bcrypt_hash"]
       )
       path        = "/etc/htpasswd"
       permissions = "644"


### PR DESCRIPTION
bcrypt() generates different result every time - Terraform doesn't store salt.
See https://github.com/hashicorp/terraform-provider-random/issues/102

So, to prevent rotating ASG at every terraform apply, store the bcrypt hash in a secret and land it in the .htpasswd file.

Also, fix target group health check. It was permanently failing.
