### PR TITLE
fix: resolve variable validation short-circuit bug for Terraform < 1.14

### DIFF
--- a/.github/workflows/terraform-CI.yml
+++ b/.github/workflows/terraform-CI.yml
@@ -14,9 +14,13 @@ concurrency:
 
 jobs:
   terraform:
-    name: 'Terraform Test'
+    name: 'Terraform Test (${{ matrix.terraform }})'
     runs-on: ["self-hosted", "Linux", "noble"]
     timeout-minutes: 240  # four hours
+    strategy:
+      fail-fast: false
+      matrix:
+        terraform: ['1.5.7', 'latest']
     env:
       ROLE_ARN: "arn:aws:iam::303467602807:role/pypiserver-tester"
       SESSION_NAME: "${{ github.event.repository.name }}-${{ github.workflow }}-${{ github.run_id }}"
@@ -40,10 +44,11 @@ jobs:
           aws-region: "us-west-2"
           role-duration-seconds: 28800  # eight hours
 
-      # Install the latest version of Terraform CLI
+      # Install Terraform CLI
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
         with:
+          terraform_version: ${{ matrix.terraform }}
           terraform_wrapper: false
 
       - name: Set up Python

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,8 @@ install-hooks:  ## Install repo hooks
 	@test -d .git/hooks || (echo "Looks like you are not in a Git repo" ; exit 1)
 	@test -L .git/hooks/pre-commit || ln -fs ../../hooks/pre-commit .git/hooks/pre-commit
 	@chmod +x .git/hooks/pre-commit
+	@test -L .git/hooks/commit-msg || ln -fs ../../hooks/commit-msg .git/hooks/commit-msg
+	@chmod +x .git/hooks/commit-msg
 
 
 .PHONY: test

--- a/variables.tf
+++ b/variables.tf
@@ -35,7 +35,7 @@ variable "asg_min_size" {
   default     = null
 
   validation {
-    condition     = var.asg_min_size == null || var.asg_min_size >= 0
+    condition     = var.asg_min_size == null ? true : var.asg_min_size >= 0
     error_message = "ASG minimum size must be >= 0 or null."
   }
 }
@@ -49,7 +49,7 @@ variable "asg_max_size" {
   default     = null
 
   validation {
-    condition     = var.asg_max_size == null || var.asg_max_size > 0
+    condition     = var.asg_max_size == null ? true : var.asg_max_size > 0
     error_message = "ASG maximum size must be > 0 or null."
   }
 }
@@ -132,7 +132,7 @@ variable "secret_readers" {
   default     = null
 
   validation {
-    condition = var.secret_readers == null || alltrue([
+    condition = var.secret_readers == null ? true : alltrue([
       for arn in var.secret_readers : can(regex("^arn:aws:iam::[0-9]{12}:role/.+$", arn))
     ])
     error_message = "All secret readers must be valid IAM role ARNs."


### PR DESCRIPTION
## Summary

- Replace `||` with ternary operators in variable validations for `asg_min_size`,
  `asg_max_size`, and `secret_readers` to fix short-circuit evaluation bug in
  Terraform < 1.14
- Add Terraform version matrix (1.5.7 + latest) to CI workflow
- Install commit-msg hook in `make install-hooks`

Fixes #34

## Test plan
- [ ] CI passes on Terraform 1.5.7
- [ ] CI passes on latest Terraform
- [ ] Verify module works with null values for asg_min_size/asg_max_size

