### PR TITLE
chore: bump dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -656,8 +656,8 @@ Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_pypiserver"></a> [pypiserver](#module\_pypiserver) | registry.infrahouse.com/infrahouse/ecs/aws | 8.1.0 |
-| <a name="module_pypiserver_secret"></a> [pypiserver\_secret](#module\_pypiserver\_secret) | registry.infrahouse.com/infrahouse/secret/aws | 1.1.1 |
+| <a name="module_pypiserver"></a> [pypiserver](#module\_pypiserver) | registry.infrahouse.com/infrahouse/ecs/aws | 8.3.1 |
+| <a name="module_pypiserver_secret"></a> [pypiserver\_secret](#module\_pypiserver\_secret) | registry.infrahouse.com/infrahouse/secret/aws | 1.3.0 |
 
 ## Resources
 

--- a/htpasswd.tf
+++ b/htpasswd.tf
@@ -7,7 +7,7 @@ resource "random_pet" "username" {}
 
 module "pypiserver_secret" {
   source             = "registry.infrahouse.com/infrahouse/secret/aws"
-  version            = "1.1.1"
+  version            = "1.3.0"
   environment        = var.environment
   secret_name_prefix = "PYPISERVER_SECRET"
   secret_description = "Username and password for the basic http authentication on the PyPI server."

--- a/main.tf
+++ b/main.tf
@@ -54,7 +54,7 @@ locals {
 }
 module "pypiserver" {
   source  = "registry.infrahouse.com/infrahouse/ecs/aws"
-  version = "8.1.0"
+  version = "8.3.1"
   providers = {
     aws     = aws
     aws.dns = aws.dns

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pytest-infrahouse ~= 0.24, >= 0.24.1
 infrahouse-core ~= 1.1
-twine ~= 6.2
+twine ~= 7.0
 
 # Documentation dependencies
 diagrams ~= 0.25


### PR DESCRIPTION
## Summary

Bumps the pending updates from the Renovate dependency dashboard (#22):

- `registry.infrahouse.com/infrahouse/ecs/aws` 8.1.0 → 8.3.1 (`main.tf`)
- `registry.infrahouse.com/infrahouse/secret/aws` 1.1.1 → 1.3.0 (`htpasswd.tf`)
- `twine` ~= 6.2 → ~= 7.0 (`requirements.txt`)

README module versions regenerated via `make docs`.

## Verification

- `make lint` passes
- `terraform init -upgrade` pulls both new module versions from the registry
- `terraform validate` succeeds via `test_data/pypiserver` root module

🤖 Generated with [Claude Code](https://claude.com/claude-code)